### PR TITLE
Fix typo in README.md and adds xmlns attribute in svg tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can pass the following options into `Initials.svg` or your `user_avatar` hel
 user_avatar(current_user.name,
   colors: 8,    # number of different colors, default: 12
   limit: 1,     # maximal initials length, default: 3
-  shape: :rect, # background shape, default: :cirlce
+  shape: :rect, # background shape, default: :circle
   size: 96      # SVG height and width in pixel, default: 32
 )
 ```

--- a/lib/initials/svg.rb
+++ b/lib/initials/svg.rb
@@ -21,7 +21,7 @@ module Initials
 
     def to_s
       svg = [
-        "<svg width='#{size}' height='#{size}'>",
+        "<svg xmlns='http://www.w3.org/2000/svg' width='#{size}' height='#{size}'>",
           shape == :rect ?
             "<rect width='#{size}' height='#{size}' rx='#{size / 32}' ry='#{size / 32}' fill='#{fill}' />"
           :

--- a/spec/svg_spec.rb
+++ b/spec/svg_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe Initials::SVG do
       end
     end
 
+    describe "svg tag" do
+      it "has valid xmlns attribute" do
+        expect(subject.to_s).to match(/^<svg xmlns='http:\/\/www.w3.org\/2000\/svg'.+<\/svg>/)
+      end
+    end
+
     describe "size" do
       let(:options) { {size: 512} }
 


### PR DESCRIPTION
This pull request does 2 things:
- Fixes a simple typo in README.md
- Adds xmlns attribute in svg tag

The xmlns attribute fixes a bug when you save the svg output in a file and try to load it on chrome, the image doesn't load without this attribute and it shows a broken image icon like this: ![image](https://user-images.githubusercontent.com/1752499/174464398-84fa3d2d-02a9-4acf-95da-ef92df1bf637.png)





